### PR TITLE
Help for error message, solves #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Your vagrant box should have ansible installed on it, if it's not the case you c
 Configure your VagrantFile with the `ansibleLocal` provisioner:
 
     config.vm.provision :ansibleLocal, :playbook => "ansible/ansible.yml"
+    
+In case your ansible version is between 1.5 and 1.8 and you are running into an error message saying `ERROR: provided hosts list is empty`, you can either add anything to your `/etc/ansible/hosts` file or change the configuration of the provisioner:
+
+    config.vm.provision :ansibleLocal, :playbook => "playbooks/playbook.yml", :raw_arguments => "-i 'localhost,'"
 
 ## Contributing
 


### PR DESCRIPTION
As described in #1, ansible version 1.5 to 1.8 has a problem running with an empty hosts file. This results in an error when trying to provision: `ERROR: provided hosts list is empty`. Either changing the hosts file or using a specific `-i` command solves this.
